### PR TITLE
Add India COVID-19 Cases visualizations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 .hgignore
 .hg/
 /resources/COVID-19/
+.idea/

--- a/resources/public/public/data/india.state-population.tsv
+++ b/resources/public/public/data/india.state-population.tsv
@@ -1,0 +1,37 @@
+State	Population
+Uttar Pradesh	199,812,341
+Maharashtra	112,374,333
+Bihar	104,099,452
+West Bengal	91,276,115
+Madhya Pradesh	72,626,809
+Tamil Nadu	72,147,030
+Rajasthan	68,548,437
+Karnataka	61,095,297
+Gujarat	60,439,692
+Andhra Pradesh	49,577,103
+Orissa	41,974,218
+Telangana	35,003,674
+Kerala	33,406,061
+Jharkhand	32,988,134
+Assam	31,205,576
+Punjab	27,743,338
+Chhattisgarh	25,545,198
+Haryana	25,351,462
+Uttaranchal	10,086,292
+Himachal Pradesh	6,864,602
+Tripura	3,673,917
+Meghalaya	2,966,889
+Manipur	2,570,390
+Nagaland	1,978,502
+Goa	1,458,545
+Arunachal Pradesh	1,383,727
+Mizoram	1,097,206
+Sikkim	610,577
+Delhi	16,787,941
+Jammu and Kashmir	12,267,032
+Puducherry	1,247,953
+Chandigarh	1,055,450
+Andaman and Nicobar	380,581
+Dadra and Nagar Haveli	344,000
+Lakshadweep	64,473
+Daman and Diu	243,247

--- a/src/appliedsciencestudio/covid19_clj_viz/explore.clj
+++ b/src/appliedsciencestudio/covid19_clj_viz/explore.clj
@@ -11,12 +11,14 @@
             [clojure.string :as string]
             [clojure.set]
             [jsonista.core :as json]
-            [oz.core :as oz]))
+            [oz.core :as oz]
+            [clojure.set :as set :refer [rename-keys]]
+            [appliedsciencestudio.covid19-clj-viz.india :as india]))
 
 (comment
-  (oz/start-server! 8082)
+  (oz/start-server! 8082))
 
-  )
+
 
 
 ;;;; ===========================================================================
@@ -141,8 +143,8 @@
                                     vals
                                     (into [])
                                     (map-indexed (fn [i n] {:cases n
-                                                           :country country
-                                                           :days-ago i}))))},
+                                                            :country country
+                                                            :days-ago i}))))},
               :mark {:type "bar" :size 24}
               :encoding {:x {:field "days-ago" :type "ordinal"
                              :sort "descending"}
@@ -184,9 +186,9 @@
                                                    :rate (jh/rate-as-of :confirmed cntry 1))))
                                         features))))))
 
-  (jh/new-daily-cases-in :deaths "Andorra")
+  (jh/new-daily-cases-in :deaths "Andorra"))
 
-  )
+
 
 (def europe-infection-datapoints
   (update europe-geojson :features
@@ -205,9 +207,9 @@
 
 (comment
   ;; Let's look at the rate of change data
-  (sort-by second (map (juxt :country :confirmed-rate) (:features europe-infection-datapoints)))
+  (sort-by second (map (juxt :country :confirmed-rate) (:features europe-infection-datapoints))))
 
-  )
+
 
 ;; The rate of infection is relatively constant across countries.
 (oz/view!
@@ -240,7 +242,7 @@
               :width 1200 :height 700
               :data {:values
                      (->> (map (fn [ctry] [ctry (zipmap jh/csv-dates (jh/country-totals ctry jh/confirmed))])
-                               (clojure.set/difference jh/countries #{"Mainland China" "China" "Others"} ))
+                               (clojure.set/difference jh/countries #{"Mainland China" "China" "Others"}))
                           (reduce (fn [vega-values [country date->cases]]
                                     (if (> 500 (apply max (vals date->cases))) ; ignore countries with fewer than X cases
                                       vega-values
@@ -258,3 +260,108 @@
                          :y {:field "cases", :type "quantitative"}
                          :color {:field "country", :type "nominal"}
                          :tooltip {:field "country", :type "nominal"}}}))
+
+;;;; ===========================================================================
+
+;; Minimum viable geographic visualization of India
+(oz/view! {:data {:url "/public/data/india-all-states.geo.json"
+                  :format {:type "json"
+                           :property "features"}}
+           :mark "geoshape"})
+
+(def india-dimensions
+  {:width 750 :height 750})
+
+(def india-geojson-with-data
+  (update (json/read-value (java.io.File. "resources/public/public/data/india-all-states.geo.json")
+                           (json/object-mapper {:decode-key-fn true}))
+          :features
+          (fn [features]
+            (mapv (fn [feature]
+                    (let [cases (get-in india/india-data [(:NAME_1 (:properties feature)) :confirmed] 0)
+                          cases (if (not(= 0 cases))
+                                  (Long/parseLong cases)
+                                  cases)
+                          pop   (get india/state-population (:NAME_1 (:properties feature)))
+                          pop (if (not(= 0 pop))
+                                (Long/parseLong (string/replace pop "," ""))
+                                pop)
+                          cases-per-100k (if (< 0 cases)
+                                           (double (/ cases (/ pop 100000)))
+                                           0)]
+                      (assoc feature
+                        :State          (:NAME_1 (:properties feature))
+                        :Cases          cases
+                        :Deaths         (get-in india/india-data [(:NAME_1 (:properties feature)) :deaths] 0)
+                        :Recovered      (get-in india/india-data [(:NAME_1 (:properties feature)) :recovered] 0)
+                        :Cases-per-100k cases-per-100k)))
+
+                  features))))
+
+(comment
+  (json/write-value (java.io.File. "resources/public/public/data/india-all-states-created.geo.json")
+                    india-geojson-with-data))
+
+(oz/view!
+  (merge-with merge oz-config india-dimensions
+              {:title {:text "Current India Covid Scenario"}
+               :data {:name "india"
+                      :values india-geojson-with-data
+                      :format {:property "features"}},
+               :mark {:type "geoshape" :stroke "white" :strokeWidth 1}
+               :encoding {:color {:field "Cases-per-100k",
+                                  :type "quantitative"
+                                  :scale {:field "cases-per-100k",
+                                          :scale {:type "log"}
+                                          :type "quantitative"}}
+                          :tooltip [{:field "State" :type "nominal"}
+                                    {:field "Cases" :type "quantitative"}
+                                    {:field "Deaths" :type "quantitative"}
+                                    {:field "Recovered" :type "quantitative"}]}
+               :selection {:highlight {:on "mouseover" :type "single"}}}))
+
+;;;; ===========================================================================
+;;;; Bar chart with Indian states
+
+(oz/view!(merge oz-config
+                {:title "Confirmed COVID19 cases in India",
+                 :data {:values (->> india/india-data
+                                     vals
+                                     (map #(select-keys % [:state :confirmed]))
+                                     (reduce (fn [acc m]
+                                               (conj acc {:state (:state m)
+                                                          :confirmed (:confirmed m)}))
+                                             [])
+                                     (sort-by :state)
+                                     ;; ;; FIXME this is the line to toggle:
+                                     (remove (comp #{"Total"} :state)))},
+                 :mark {:type "bar" :color "#9085DA"}
+                 :encoding {:x {:field "confirmed", :type "quantitative"}
+                            :y {:field "state", :type "ordinal"
+                                :sort nil}}}))
+
+;;;; Bar chart with Indian states and Chinese provinces
+
+(oz/view!
+  (merge oz-config
+         {:title "Confirmed COVID19 cases in China and India",
+          :data {:values (let [date "2020-03-19"]
+                           (->> jh/confirmed
+                                ;; Notice improved readability from working with seq of maps:
+                                (map #(select-keys % [:province-state :country-region date]))
+                                (filter (comp #{"China" "Mainland China"} :country-region))
+                                (reduce (fn [acc m]
+                                          (conj acc {:state-province (:province-state m)
+                                                     :confirmed (get m date)}))
+                                        [])
+                                (concat (->> india/india-data
+                                             vals
+                                             (map (comp #(select-keys % [:state-province :confirmed])
+                                                        #(rename-keys % {:state :state-province})))
+                                             (sort-by :state)))
+                                ;; ;; FIXME this is the line to toggle:
+                                (remove (comp #{"Hubei"} :state-province))))},
+          :mark {:type "bar" :color "#9085DA"}
+          :encoding {:x {:field "confirmed", :type "quantitative"}
+                     :y {:field "state-province", :type "ordinal"
+                         :sort nil}}}))

--- a/src/appliedsciencestudio/covid19_clj_viz/explore.clj
+++ b/src/appliedsciencestudio/covid19_clj_viz/explore.clj
@@ -121,10 +121,10 @@
   (vals (take 10 (sort-by key #(compare %2 %1) (jh/new-daily-cases-in :confirmed "Germany"))))
   ;; (1477 1210 910 1597 170 451 281 136 241 129)
 
-  (vals (take 10 (sort-by key #(compare %2 %1) (jh/new-daily-cases-in :confirmed "Italy"))))
+  (vals (take 10 (sort-by key #(compare %2 %1) (jh/new-daily-cases-in :confirmed "Italy")))))
   ;; (3233 3590 3497 5198 0 2313 977 1797 1492 1247)
   
-  )
+
 
 
 ;;;; ===========================================================================
@@ -359,8 +359,8 @@
                                              (map (comp #(select-keys % [:state-province :confirmed])
                                                         #(rename-keys % {:state :state-province})))
                                              (sort-by :state)))
-                                ;; ;; FIXME this is the line to toggle:
-                                (remove (comp #{"Hubei"} :state-province))))},
+                                (remove (comp #{"Hubei"} :state-province))
+                                (remove (comp #{"Total"} :state-province))))},
           :mark {:type "bar" :color "#9085DA"}
           :encoding {:x {:field "confirmed", :type "quantitative"}
                      :y {:field "state-province", :type "ordinal"

--- a/src/appliedsciencestudio/covid19_clj_viz/india.clj
+++ b/src/appliedsciencestudio/covid19_clj_viz/india.clj
@@ -1,0 +1,20 @@
+(ns appliedsciencestudio.covid19-clj-viz.india
+  (:require [jsonista.core :as json]
+            [meta-csv.core :as mcsv]))
+
+(defonce india-covid-data (slurp "https://api.covid19india.org/data.json"))
+
+(def state-population
+  "From https://en.wikipedia.org/wiki/List_of_states_and_union_territories_of_India_by_population"
+  (let [state-population-list (mcsv/read-csv "resources/india.state-population.tsv")
+        state-population-map  (into {} (mapv (fn [each-state]
+                                               (-> (first each-state)
+                                                   (hash-map (second each-state)))) state-population-list))]
+    state-population-map))
+
+(def india-data
+  (->> (json/read-value india-covid-data (json/object-mapper {:decode-key-fn true}))
+       :statewise
+       (mapv (fn [each-state-data] (-> (:state each-state-data)
+                                       (hash-map each-state-data))))
+       (into {})))


### PR DESCRIPTION
- Have added a Choropleth : Indian states' COVID19 confirmed, deaths, recovered cases per 100k of population.
- Have added a Bar chart with Indian states confirmed cases. 
- Have added a Bar chart with Indian states and Chinese provinces COVID-19 confirmed cases. 